### PR TITLE
available date depend on selected language format

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -783,8 +783,19 @@ class ProductLazyArray extends AbstractLazyArray
             if (isset($product['stock_quantity'])) {
                 $availableQuantity = $product['stock_quantity'] - $product['quantity_wanted'];
             }
+            
+            $available_date = $product['available_date'];
+            if( !empty($available_date) ) {
+                $formated_date = \DateTime::createFromFormat(
+                    'Y-m-d', 
+                    $available_date
+                );
+                if( $formated_date )
+                    $available_date = $formated_date->format($this->language->date_format_lite);
+            }
+            
             if ($availableQuantity >= 0) {
-                $this->product['availability_date'] = $product['available_date'];
+                $this->product['availability_date'] = $available_date;
 
                 if ($product['quantity'] < $settings->lastRemainingItems) {
                     $this->applyLastItemsInStockDisplayRule();
@@ -796,7 +807,7 @@ class ProductLazyArray extends AbstractLazyArray
             } elseif ($product['allow_oosp']) {
                 $this->product['availability_message'] = $product['available_later'] ? $product['available_later']
                     : Configuration::get('PS_LABEL_OOS_PRODUCTS_BOA', $language->id);
-                $this->product['availability_date'] = $product['available_date'];
+                $this->product['availability_date'] = $available_date;
                 $this->product['availability'] = 'available';
             } elseif ($product['quantity_wanted'] > 0 && $product['quantity'] > 0) {
                 $this->product['availability_message'] = $this->translator->trans(
@@ -812,12 +823,12 @@ class ProductLazyArray extends AbstractLazyArray
                     [],
                     'Shop.Theme.Catalog'
                 );
-                $this->product['availability_date'] = $product['available_date'];
+                $this->product['availability_date'] = $available_date;
                 $this->product['availability'] = 'unavailable';
             } else {
                 $this->product['availability_message'] =
                     Configuration::get('PS_LABEL_OOS_PRODUCTS_BOD', $language->id);
-                $this->product['availability_date'] = $product['available_date'];
+                $this->product['availability_date'] = $available_date;
                 $this->product['availability'] = 'unavailable';
             }
         } else {


### PR DESCRIPTION
Displaying the date depending on the format of the selected language

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.7.x
| Description?  | the availability date display is incorrect when choosing an other language (eg 🇫🇷 )
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | update stock to 0, and put an availability date, then go to the product details to see the result

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
